### PR TITLE
Basic campaign creation/management

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,47 @@
+# Include any files or directories that you don't want to be copied to your
+# container here (e.g., local build artifacts, temporary files, etc.).
+#
+# For more help, visit the .dockerignore file reference guide at
+# https://docs.docker.com/go/build-context-dockerignore/
+
+# IDE / tooling files
+.vscode
+*.log
+*.jfm
+*.dbmdl
+*.proj.user
+.project
+.settings
+.toolstarget
+.classpath
+
+# Git
+.git
+.gitignore
+
+# Docker / Compose metadata
+Dockerfile*
+docker-compose*
+compose.y*ml
+
+# Node / Build files
+node_modules
+dist
+build
+coverage
+npm-debug.log
+
+# Framework-specific
+.next
+.cache
+charts
+obj
+
+# Secrets / Local config
+secrets.dev.yaml
+values.dev.yaml
+
+# Misc
+LICENSE
+README.md
+

--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://postgres:Abc123%21%40%23@localhost:5432/postgres
+DATABASE_URL=postgres://postgres:Abc123%21%40%23@db:5432/postgres

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy to AWS Fargate
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Deploy to ECS
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Build, Tag, and Push Docker Image
+        run: |
+          IMAGE_URI=${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:latest
+          docker build -t $IMAGE_URI .
+          docker push $IMAGE_URI
+        env:
+          ECR_REPOSITORY: ${{ secrets.ECR_REPOSITORY }}
+
+      - name: Fill in new image in ECS task definition
+        id: task-def
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
+        with:
+          task-definition: ${{ secrets.ECS_TASK_DEFINITION }}
+          container-name: ${{ secrets.CONTAINER_NAME }}
+          image: ${{ steps.login-ecr.outputs.registry }}/${{ secrets.ECR_REPOSITORY }}:latest
+
+      - name: Deploy to ECS Service
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
+        with:
+          cluster: ${{ secrets.ECS_CLUSTER }}
+          service: ${{ secrets.ECS_SERVICE }}
+          task-definition: ${{ steps.task-def.outputs.task-definition }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+ARG NODE_VERSION=22.15.1
+FROM node:${NODE_VERSION}-alpine
+
+WORKDIR /usr/src/app
+
+COPY package*.json ./
+
+RUN npm install
+
+COPY . .
+
+# Expose Fastify port
+EXPOSE 5000
+
+# Run `drizzle:push` then start Fastify server
+CMD ["npx", "tsx", "main.ts"]
+

--- a/README.Docker.md
+++ b/README.Docker.md
@@ -1,0 +1,22 @@
+### Building and running your application
+
+When you're ready, start your application by running:
+`docker compose up --build`.
+
+Your application will be available at http://localhost:5000.
+
+### Deploying your application to the cloud
+
+First, build your image, e.g.: `docker build -t myapp .`.
+If your cloud uses a different CPU architecture than your development
+machine (e.g., you are on a Mac M1 and your cloud provider is amd64),
+you'll want to build the image for that platform, e.g.:
+`docker build --platform=linux/amd64 -t myapp .`.
+
+Then, push it to your registry, e.g. `docker push myregistry.com/myapp`.
+
+Consult Docker's [getting started](https://docs.docker.com/go/get-started-sharing/)
+docs for more detail on building and pushing.
+
+### References
+* [Docker's Node.js guide](https://docs.docker.com/language/nodejs/)

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,41 @@
+services:
+  server:
+    build:
+      context: .
+    environment:
+      NODE_ENV: production
+    ports:
+      - 5000:5000
+    depends_on:
+      db:
+        condition: service_healthy
+    env_file:
+      - .env
+    command: sh -c "npx drizzle-kit push && npx tsx main.ts"
+    networks:
+      - app-net
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: Abc123!@#
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - app-net
+
+volumes:
+  postgres_data:
+
+networks:
+  app-net:
+    external: true

--- a/database/database.ts
+++ b/database/database.ts
@@ -1,7 +1,7 @@
 import dotenv from 'dotenv';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
-import * as schema from '../models/user.ts';
+import * as schema from '../models/users.ts';
 
 dotenv.config(); //Load .env before anything else
 

--- a/database/database.ts
+++ b/database/database.ts
@@ -1,7 +1,9 @@
 import dotenv from 'dotenv';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
-import * as schema from '../models/users.ts';
+import { notes } from '../models/notes.ts';
+import {users} from '../models/users.ts';
+import {folders} from '../models/folders.ts';
 
 dotenv.config(); //Load .env before anything else
 
@@ -9,4 +11,4 @@ const pool = new Pool({
   connectionString: process.env.DATABASE_URL, // Setup db connection based on DB URL
 }); 
 
-export const db = drizzle(pool, { schema }); // Schema-aware DB instance
+export const db = drizzle(pool, { schema : {notes, users, folders}}); // Schema-aware DB instance

--- a/database/database.ts
+++ b/database/database.ts
@@ -1,14 +1,14 @@
-import dotenv from 'dotenv';
-import { drizzle } from 'drizzle-orm/node-postgres';
-import { Pool } from 'pg';
-import { notes } from '../models/notes.ts';
-import {users} from '../models/users.ts';
-import {folders} from '../models/folders.ts';
+import dotenv from "dotenv";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { notes } from "../models/notes.ts";
+import { users } from "../models/users.ts";
+import { folders } from "../models/folders.ts";
 
 dotenv.config(); //Load .env before anything else
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL, // Setup db connection based on DB URL
-}); 
+});
 
-export const db = drizzle(pool, { schema : {notes, users, folders}}); // Schema-aware DB instance
+export const db = drizzle(pool, { schema: { notes, users, folders } }); // Schema-aware DB instance

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,10 +1,10 @@
-import 'dotenv/config';
-import { defineConfig } from 'drizzle-kit';
+import "dotenv/config";
+import { defineConfig } from "drizzle-kit";
 
 export default defineConfig({
-  out: './drizzle/migrations',
-  schema: './models/**/*.ts',
-  dialect: 'postgresql',
+  out: "./drizzle/migrations",
+  schema: "./models/**/*.ts",
+  dialect: "postgresql",
   dbCredentials: {
     url: process.env.DATABASE_URL!,
   },

--- a/main.ts
+++ b/main.ts
@@ -23,7 +23,7 @@ fastify.register(fCookie, {
 fastify.register(jwt, {
   secret: "supersecretstring",
   cookie: {
-    cookieName: "token",
+    cookieName: "Authorization",
     signed: false,
   },
 });
@@ -31,6 +31,7 @@ fastify.register(jwt, {
 fastify.register(cors, {
   origin: "http://localhost:5173", //Frontend localhost url
   credentials: true,
+  methods: ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"],
 });
 
 // Decorator for protected routes

--- a/main.ts
+++ b/main.ts
@@ -3,8 +3,6 @@ import userRoutes from "./routes/users";
 import fCookie from "@fastify/cookie";
 import jwt from "@fastify/jwt";
 import cors from "@fastify/cors";
-import { migrate } from "drizzle-orm/node-postgres/migrator";
-import { db } from "./database/database";
 import authRoutes from "./routes/authentication";
 import campaignRoutes from "./routes/campaign";
 import folderRoutes from "./routes/folder";
@@ -58,7 +56,10 @@ fastify.get("/", async (request, reply) => {
 // Start the server
 const start = async () => {
   try {
-    await fastify.listen({ port: PORT });
+    await fastify.listen({
+      port: PORT,
+      host: "0.0.0.0",
+    });
     console.log(`🚀 Server is running at http://localhost:${PORT}`);
   } catch (error) {
     fastify.log.error(error);

--- a/main.ts
+++ b/main.ts
@@ -1,34 +1,36 @@
-import Fastify from 'fastify';
-import userRoutes from './routes/users';
-import fCookie from '@fastify/cookie';
-import jwt from '@fastify/jwt';
-import cors from '@fastify/cors';
-import { migrate } from 'drizzle-orm/node-postgres/migrator';
-import { db } from './database/database';
-import authRoutes from './routes/authentication';
-
+import Fastify from "fastify";
+import userRoutes from "./routes/users";
+import fCookie from "@fastify/cookie";
+import jwt from "@fastify/jwt";
+import cors from "@fastify/cors";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { db } from "./database/database";
+import authRoutes from "./routes/authentication";
+import campaignRoutes from "./routes/campaign";
+import folderRoutes from "./routes/folder";
+import notesRoutes from "./routes/notes";
 
 const fastify = Fastify({ logger: true });
 
 const PORT = 5000;
 
 // Register plugins
+
+fastify.register(fCookie, {
+  secret: "some-secret-key",
+});
+
 fastify.register(jwt, {
-  secret: 'supersecretstring',
+  secret: "supersecretstring",
   cookie: {
-    cookieName: 'token',
+    cookieName: "token",
     signed: false, // or true if you're signing it with @fastify/cookie
   },
 });
 
-fastify.register(fCookie, {
-  secret: 'some-secret-key',
-});
-
-
 fastify.register(cors, {
-  origin: 'http://localhost:5173', //Frontend localhost url
-  credentials: true,               
+  origin: "http://localhost:5173", //Frontend localhost url
+  credentials: true,
 });
 
 // Decorator for protected routes
@@ -41,12 +43,15 @@ fastify.decorate("authenticate", async function (request, reply) {
 });
 
 // Register routes
-fastify.register(userRoutes, { prefix: '/user' });
+fastify.register(userRoutes, { prefix: "/user" });
 fastify.register(authRoutes);
+fastify.register(campaignRoutes, { prefix: "/campaign" });
+fastify.register(folderRoutes, { prefix: "/folder" });
+fastify.register(notesRoutes, { prefix: "/notes" });
 
 // Root route
-fastify.get('/', async (request, reply) => {
-  reply.send({ hello: 'world' });
+fastify.get("/", async (request, reply) => {
+  reply.send({ hello: "world" });
 });
 
 // Start the server
@@ -61,4 +66,3 @@ const start = async () => {
 };
 
 start();
-

--- a/main.ts
+++ b/main.ts
@@ -24,7 +24,7 @@ fastify.register(jwt, {
   secret: "supersecretstring",
   cookie: {
     cookieName: "token",
-    signed: false, // or true if you're signing it with @fastify/cookie
+    signed: false,
   },
 });
 

--- a/models/folderItems.ts
+++ b/models/folderItems.ts
@@ -1,0 +1,14 @@
+import { pgTable, integer, varchar, timestamp } from "drizzle-orm/pg-core";
+
+import { folders } from "./folders";
+
+export const folderItems = pgTable("folder_items", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  folderId: integer("folder_id")
+    .references(() => folders.id)
+    .notNull(),
+  type: varchar({ length: 50 }).notNull(), // e.g. 'note', 'entity', 'folder'
+  refId: integer("ref_id").notNull(), // ID in the referenced table for that type
+  position: integer().notNull(), // used for manual ordering
+  createdAt: timestamp({ withTimezone: true }).defaultNow(),
+});

--- a/models/folderItems.ts
+++ b/models/folderItems.ts
@@ -10,5 +10,4 @@ export const folderItems = pgTable("folder_items", {
   type: varchar({ length: 50 }).notNull(), // e.g. 'note', 'entity', 'folder'
   refId: integer("ref_id").notNull(), // ID in the referenced table for that type
   position: integer().notNull(), // used for manual ordering
-  createdAt: timestamp({ withTimezone: true }).defaultNow(),
 });

--- a/models/folderItems.ts
+++ b/models/folderItems.ts
@@ -3,11 +3,11 @@ import { pgTable, integer, varchar, timestamp } from "drizzle-orm/pg-core";
 import { folders } from "./folders";
 
 export const folderItems = pgTable("folder_items", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  folderId: integer("folder_id")
+  id: integer().primaryKey().generatedAlwaysAsIdentity(), // Unique ID for each item within a folder
+  folderId: integer("folder_id") //Id of the folder this item belongs to
     .references(() => folders.id)
     .notNull(),
   type: varchar({ length: 50 }).notNull(), // e.g. 'note', 'entity', 'folder'
-  refId: integer("ref_id").notNull(), // ID in the referenced table for that type
+  refId: integer("ref_id").notNull(), // ID in the referenced table for that item
   position: integer().notNull(), // used for manual ordering
 });

--- a/models/folders.ts
+++ b/models/folders.ts
@@ -1,0 +1,10 @@
+import { integer, pgTable, varchar, boolean, json} from "drizzle-orm/pg-core";
+import { users } from "./users";
+
+export const folders = pgTable("folders", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  name: varchar({ length: 255 }).notNull(),
+  isCampaign: boolean().default(false),
+  settings: json(), // campaign config
+  createdBy: integer().references(() => users.id).notNull()
+});

--- a/models/folders.ts
+++ b/models/folders.ts
@@ -1,4 +1,4 @@
-import { integer, pgTable, varchar, boolean, json} from "drizzle-orm/pg-core";
+import { integer, pgTable, varchar, boolean, json } from "drizzle-orm/pg-core";
 import { users } from "./users";
 
 export const folders = pgTable("folders", {
@@ -6,5 +6,7 @@ export const folders = pgTable("folders", {
   name: varchar({ length: 255 }).notNull(),
   isCampaign: boolean().default(false),
   settings: json(), // campaign config
-  createdBy: integer().references(() => users.id).notNull()
+  createdBy: integer()
+    .references(() => users.id)
+    .notNull(),
 });

--- a/models/notes.ts
+++ b/models/notes.ts
@@ -1,0 +1,15 @@
+import {
+  pgTable,
+  integer,
+  varchar,
+  text
+} from "drizzle-orm/pg-core";
+
+import { users } from "./users";
+
+export const notes = pgTable("notes", {
+  id: integer().primaryKey().generatedAlwaysAsIdentity(),
+  title: varchar({ length: 255 }),
+  content: text(),
+  createdBy: integer().references(() => users.id).notNull(),
+});

--- a/models/notes.ts
+++ b/models/notes.ts
@@ -1,9 +1,4 @@
-import {
-  pgTable,
-  integer,
-  varchar,
-  text
-} from "drizzle-orm/pg-core";
+import { pgTable, integer, varchar, text } from "drizzle-orm/pg-core";
 
 import { users } from "./users";
 
@@ -11,5 +6,7 @@ export const notes = pgTable("notes", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   title: varchar({ length: 255 }),
   content: text(),
-  createdBy: integer().references(() => users.id).notNull(),
+  createdBy: integer()
+    .references(() => users.id)
+    .notNull(),
 });

--- a/models/users.ts
+++ b/models/users.ts
@@ -6,5 +6,3 @@ export const users = pgTable("users", {
   password: varchar({ length: 255 }).notNull()  //
   //email: varchar({ length: 255 }).notNull().unique(),  //Email later
 });
-
-export default users;

--- a/models/users.ts
+++ b/models/users.ts
@@ -3,6 +3,6 @@ import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
 export const users = pgTable("users", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   name: varchar({ length: 255 }).notNull(),
-  password: varchar({ length: 255 }).notNull()  //
+  password: varchar({ length: 255 }).notNull(), //
   //email: varchar({ length: 255 }).notNull().unique(),  //Email later
 });

--- a/models/users.ts
+++ b/models/users.ts
@@ -1,9 +1,10 @@
 import { integer, pgTable, varchar } from "drizzle-orm/pg-core";
 
-
 export const users = pgTable("users", {
   id: integer().primaryKey().generatedAlwaysAsIdentity(),
   name: varchar({ length: 255 }).notNull(),
   password: varchar({ length: 255 }).notNull()  //
   //email: varchar({ length: 255 }).notNull().unique(),  //Email later
 });
+
+export default users;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1831,6 +1831,18 @@
       "license": "MIT"
     },
     "node_modules/fastify-static": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-4.7.0.tgz",
+      "integrity": "sha512-zZhCfJv/hkmud2qhWqpU3K9XVAuy3+IV8Tp9BC5J5U+GyA2XwoB6h8lh9GqpEIqdXOw01WyWQllV7dOWVyAlXg==",
+      "deprecated": "Please use @fastify/static@5.0.0 instead",
+      "license": "MIT",
+      "dependencies": {
+        "fastify-static-deprecated": "npm:fastify-static@4.6.1",
+        "process-warning": "^1.0.0"
+      }
+    },
+    "node_modules/fastify-static-deprecated": {
+      "name": "fastify-static",
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/fastify-static/-/fastify-static-4.6.1.tgz",
       "integrity": "sha512-vy7N28U4AMhuOim12ZZWHulEE6OQKtzZbHgiB8Zj4llUuUQXPka0WHAQI3njm1jTCx4W6fixUHfpITxweMtAIA==",
@@ -1844,6 +1856,12 @@
         "readable-stream": "^3.4.0",
         "send": "^0.17.1"
       }
+    },
+    "node_modules/fastify-static/node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q==",
+      "license": "MIT"
     },
     "node_modules/fastify-swagger": {
       "version": "5.2.0",

--- a/routes/authentication.ts
+++ b/routes/authentication.ts
@@ -16,6 +16,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
         password: string;
       };
 
+      //Finds the user by name
       const user = await db.query.users.findFirst({
         where: (users, { eq }) => eq(users.name, name),
       });
@@ -30,6 +31,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
 
       const token = fastify.jwt.sign({ name });
 
+      // Set the token in a secure cookie
       reply.setCookie("token", token, {
         httpOnly: true,
         secure: true,
@@ -58,6 +60,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
 async function registerHandler(request, reply) {
   const { name, password } = request.body as { name: string; password: string };
 
+  // Check if the user already exists
   const existingUser = await db.query.users.findFirst({
     where: (users, { eq }) => eq(users.name, name),
   });

--- a/routes/authentication.ts
+++ b/routes/authentication.ts
@@ -1,72 +1,80 @@
-import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
-import { db } from '../database/database';
-import { users } from '../models/users';
-import bcrypt from 'bcrypt';
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import { db } from "../database/database";
+import { users } from "../models/users";
+import bcrypt from "bcrypt";
 
 const authRoutes: FastifyPluginAsync = async (fastify) => {
-
   // Register Handler
   fastify.post("/register", registerHandler);
 
   // Login Handler
-    fastify.post("/login", async (request:FastifyRequest, reply:FastifyReply) => {
+  fastify.post(
+    "/login",
+    async (request: FastifyRequest, reply: FastifyReply) => {
+      const { name, password } = request.body as {
+        name: string;
+        password: string;
+      };
+
+      const user = await db.query.users.findFirst({
+        where: (users, { eq }) => eq(users.name, name),
+      });
+
+      const isMatch = user && (await bcrypt.compare(password, user.password));
+
+      if (!user || !isMatch) {
+        return reply.code(401).send({
+          message: "Invalid name or password",
+        });
+      }
+
+      const token = fastify.jwt.sign({ name });
+
+      reply.setCookie("token", token, {
+        httpOnly: true,
+        secure: true,
+        sameSite: "none",
+        path: "/",
+        maxAge: 60 * 60 * 24, // 1 day
+      });
+
+      return reply.send({ message: "Login successful" });
+    }
+  );
+
+  //Me authenticator Checker
+  fastify.get(
+    "/me",
+    {
+      preHandler: [fastify.authenticate],
+    },
+    async (request, reply) => {
+      const user = request.user as { name: string };
+      return { user };
+    }
+  );
+};
+
+async function registerHandler(request, reply) {
   const { name, password } = request.body as { name: string; password: string };
 
-  const user = await db.query.users.findFirst({
+  const existingUser = await db.query.users.findFirst({
     where: (users, { eq }) => eq(users.name, name),
   });
 
-  const isMatch = user && (await bcrypt.compare(password, user.password));
-
-  if (!user || !isMatch) {
+  if (existingUser) {
     return reply.code(401).send({
-      message: 'Invalid name or password',
+      message: "User already exists with this name",
     });
   }
 
-  const token = fastify.jwt.sign({ name });
-
-    reply.setCookie('token', token, {
-    httpOnly: true,
-    secure: true,            
-    sameSite: 'none',        
-    path: '/',
-    maxAge: 60 * 60 * 24,    // 1 day
-    });
-
-    return reply.send({ message: "Login successful" });
-    });
-
-    //Me authenticator Checker
-    fastify.get('/me', {
-        preHandler: [fastify.authenticate],
-        }, async (request, reply) => {
-        const user = request.user as { name: string };
-        return { user };
-    });
-
-};
-
-async function registerHandler(request,reply) {
-const { name, password } = request.body as { name: string; password: string };
-
-const existingUser = await db.query.users.findFirst({
-    where: (users, { eq }) => eq(users.name, name),
-});
-
-if (existingUser) {
-    return reply.code(401).send({
-    message: 'User already exists with this name',
-    });
-}
-
-try {
+  try {
     const hash = await bcrypt.hash(password, 10);
     await db.insert(users).values({ name, password: hash });
     return reply.code(201).send({ message: "User registered" });
-} catch (e) {
+  } catch (e) {
     return reply.code(500).send({ message: "Internal server error" });
-}
+  }
 }
 
 export default authRoutes;

--- a/routes/authentication.ts
+++ b/routes/authentication.ts
@@ -51,8 +51,8 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
       preHandler: [fastify.authenticate],
     },
     async (request, reply) => {
-      const user = request.user as { name: string };
-      return { user };
+      const user = request.user as { id: number; name: string };
+      return { user: { id: user.id, name: user.name } };
     }
   );
 };

--- a/routes/authentication.ts
+++ b/routes/authentication.ts
@@ -38,7 +38,7 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
         maxAge: 60 * 60 * 24, // 1 day
       });
 
-      return reply.send({ message: "Login successful" });
+      return reply.send({ message: "Login successful", UserId: user.id });
     }
   );
 

--- a/routes/authentication.ts
+++ b/routes/authentication.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync, FastifyReply, FastifyRequest } from 'fastify';
 import { db } from '../database/database';
-import { users } from '../models/user';
+import { users } from '../models/users';
 import bcrypt from 'bcrypt';
 
 const authRoutes: FastifyPluginAsync = async (fastify) => {

--- a/routes/authentication.ts
+++ b/routes/authentication.ts
@@ -6,6 +6,7 @@ import bcrypt from "bcrypt";
 const authRoutes: FastifyPluginAsync = async (fastify) => {
   // Register Handler
   fastify.post("/register", registerHandler);
+  fastify.get("/logout", logout);
 
   // Login Handler
   fastify.post(
@@ -29,13 +30,13 @@ const authRoutes: FastifyPluginAsync = async (fastify) => {
         });
       }
 
-      const token = fastify.jwt.sign({ name });
+      const token = fastify.jwt.sign({ id: user.id, name });
 
       // Set the token in a secure cookie
-      reply.setCookie("token", token, {
+      reply.setCookie("Authorization", token, {
         httpOnly: true,
-        secure: true,
-        sameSite: "none",
+        secure: false,
+        sameSite: "lax",
         path: "/",
         maxAge: 60 * 60 * 24, // 1 day
       });
@@ -78,6 +79,18 @@ async function registerHandler(request, reply) {
   } catch (e) {
     return reply.code(500).send({ message: "Internal server error" });
   }
+}
+
+async function logout(request: FastifyRequest, reply: FastifyReply) {
+  // Clear the cookie
+  reply.clearCookie("Authorization", {
+    path: "/", // Must match the path used when setting the cookie
+    httpOnly: true, // Matches original
+    sameSite: "lax", // Matches original
+    secure: false, // Matches original (change to true in production)
+  });
+
+  return reply.code(200);
 }
 
 export default authRoutes;

--- a/routes/campaign.ts
+++ b/routes/campaign.ts
@@ -68,6 +68,7 @@ async function joinCampaign(request: FastifyRequest, reply: FastifyReply) {
     return reply.code(400).send({ error: "Invalid folderId or userId" });
   }
 
+  //Find the campaign folder and check if it is a campaign
   const campaign = await db.query.folders.findFirst({
     where: (folders, { eq, and }) =>
       and(eq(folders.id, numericFolderId), eq(folders.isCampaign, true)),
@@ -80,9 +81,11 @@ async function joinCampaign(request: FastifyRequest, reply: FastifyReply) {
   const settings = (campaign.settings ?? {}) as CampaignSettings;
   const users = Array.isArray(settings.users) ? settings.users : [];
 
+  //Check if the user is already in the campaign
   if (!users.includes(numericUserId)) {
     users.push(numericUserId);
 
+    // Update the campaign settings with the new user
     await db
       .update(folders)
       .set({ settings: { ...settings, users } })

--- a/routes/campaign.ts
+++ b/routes/campaign.ts
@@ -1,11 +1,95 @@
 import { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import { db } from "../database/database";
+import { folders } from "../models/folders";
+import { eq, and } from "drizzle-orm";
 
-const authRoutes: FastifyPluginAsync = async (fastify) => {
-    fastify.post("/", campaignCreationHandler);
+const campaignRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post("/", campaignCreationHandler);
+  fastify.get("/:userId", campaignGetHandler);
+  fastify.post("/join/:folderId/:userId", joinCampaign);
+};
+
+async function campaignCreationHandler(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  const { name, createdBy } = request.body as {
+    name: string;
+    createdBy: number;
+  };
+
+  const campaign = await db
+    .insert(folders)
+    .values({
+      name,
+      isCampaign: true,
+      settings: { users: [createdBy] },
+      createdBy,
+    })
+    .returning();
+
+  return reply.code(201).send(campaign[0]);
 }
 
-async function campaignCreationHandler(request:FastifyRequest, reply:FastifyReply) {
-    
+async function campaignGetHandler(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  const { userId } = request.params as { userId: number };
+
+  const campaigns = await db
+    .select({ id: folders.id, name: folders.name })
+    .from(folders)
+    .where(and(eq(folders.createdBy, userId), eq(folders.isCampaign, true)));
+
+  if (campaigns.length === 0) {
+    return reply.code(404).send({ error: "No campaigns found" });
+  }
+
+  return reply.code(200).send(campaigns);
 }
 
-export default authRoutes;
+type CampaignSettings = {
+  users: number[];
+  [key: string]: any;
+};
+
+async function joinCampaign(request: FastifyRequest, reply: FastifyReply) {
+  let { userId, folderId } = request.params as {
+    userId: string;
+    folderId: string;
+  };
+
+  //Need to convert userId and folderId to numbers or else will be done as a String instead
+  const numericUserId = parseInt(userId, 10);
+  const numericFolderId = parseInt(folderId, 10);
+
+  if (isNaN(numericUserId) || isNaN(numericFolderId)) {
+    return reply.code(400).send({ error: "Invalid folderId or userId" });
+  }
+
+  const campaign = await db.query.folders.findFirst({
+    where: (folders, { eq, and }) =>
+      and(eq(folders.id, numericFolderId), eq(folders.isCampaign, true)),
+  });
+
+  if (!campaign) {
+    return reply.code(404).send({ error: "Campaign not found" });
+  }
+
+  const settings = (campaign.settings ?? {}) as CampaignSettings;
+  const users = Array.isArray(settings.users) ? settings.users : [];
+
+  if (!users.includes(numericUserId)) {
+    users.push(numericUserId);
+
+    await db
+      .update(folders)
+      .set({ settings: { ...settings, users } })
+      .where(eq(folders.id, numericFolderId));
+  }
+
+  return reply.code(200).send({ message: "Campaign joined successfully" });
+}
+
+export default campaignRoutes;

--- a/routes/campaign.ts
+++ b/routes/campaign.ts
@@ -1,0 +1,11 @@
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+
+const authRoutes: FastifyPluginAsync = async (fastify) => {
+    fastify.post("/", campaignCreationHandler);
+}
+
+async function campaignCreationHandler(request:FastifyRequest, reply:FastifyReply) {
+    
+}
+
+export default authRoutes;

--- a/routes/folder.ts
+++ b/routes/folder.ts
@@ -31,7 +31,7 @@ async function folderCreationHandler(
     name: string;
     createdBy: number;
     settings?: JSON;
-    folderId?: number; // Optional to support nested folders
+    folderId: number; //Required if this folder is a subfolder
   };
 
   //Create the folder
@@ -154,7 +154,9 @@ async function folderUpdateHandler(
     .where(eq(folders.id, folderId))
     .returning();
 
-  return reply.code(200).send(updatedFolder[0]);
+  return reply
+    .code(200)
+    .send({ message: "Folder updated", folder: updatedFolder[0] });
 }
 
 async function folderMovementHandler(

--- a/routes/folder.ts
+++ b/routes/folder.ts
@@ -1,0 +1,258 @@
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import { db } from "../database/database";
+import { folders } from "../models/folders";
+import { folderItems } from "../models/folderItems";
+import { notes } from "../models/notes";
+
+import {
+  eq,
+  count as drizzleCount,
+  and,
+  gt,
+  gte,
+  lt,
+  lte,
+  sql,
+} from "drizzle-orm";
+
+const folderRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post("/", folderCreationHandler);
+  fastify.get("/:folderId", folderGetHandler);
+  fastify.patch("/", folderUpdateHandler);
+  fastify.delete("/:folderId", deleteFolderHandler);
+};
+
+async function folderCreationHandler(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  const { name, createdBy, settings, folderId } = request.body as {
+    name: string;
+    createdBy: number;
+    settings?: JSON;
+    folderId?: number; // Optional to support nested folders
+  };
+
+  //Create the folder
+  const [folder] = await db
+    .insert(folders)
+    .values({
+      name,
+      isCampaign: false,
+      settings: settings ?? {},
+      createdBy,
+    })
+    .returning();
+
+  //Add to parent folder via folder_items
+  if (folderId) {
+    // Determine the next position
+    const [{ count }] = await db
+      .select({ count: drizzleCount() })
+      .from(folderItems)
+      .where(eq(folderItems.folderId, folderId));
+
+    const position = Number(count); // Add to end
+
+    await db.insert(folderItems).values({
+      folderId,
+      type: "folder",
+      refId: folder.id,
+      position,
+    });
+  }
+
+  return reply.code(201).send(folder);
+}
+
+async function folderGetHandler(request: FastifyRequest, reply: FastifyReply) {
+  const { folderId } = request.params as { folderId: number };
+
+  //Main folder query
+  const folder = await db.query.folders.findFirst({
+    columns: {
+      id: true,
+      name: true,
+      settings: true,
+    },
+    where: eq(folders.id, folderId),
+  });
+
+  if (!folder) {
+    return reply.code(404).send({ error: "Folder not found" });
+  }
+
+  //Fetch items in the folder
+  const items = await db
+    .select({
+      id: folderItems.id,
+      type: folderItems.type,
+      refId: folderItems.refId,
+      position: folderItems.position,
+    })
+    .from(folderItems)
+    .where(eq(folderItems.folderId, folderId))
+    .orderBy(folderItems.position);
+
+  //Hydrate items with their data
+  const hydratedItems = await Promise.all(
+    items.map(async (item) => {
+      let data: any = null;
+
+      if (item.type === "note") {
+        data =
+          (await db.query.notes.findFirst({
+            where: eq(notes.id, item.refId),
+          })) ?? null;
+      } else if (item.type === "folder") {
+        data =
+          (await db.query.folders.findFirst({
+            where: eq(folders.id, item.refId),
+          })) ?? null;
+      }
+
+      return { ...item, data };
+    })
+  );
+
+  return {
+    ...folder,
+    items: hydratedItems,
+  };
+}
+
+async function folderUpdateHandler(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  const { itemId, toFolderId, newPosition } = request.body as {
+    itemId: number;
+    toFolderId: number;
+    newPosition: number;
+  };
+
+  // Fetch the item being moved
+  const item = await db
+    .select()
+    .from(folderItems)
+    .where(eq(folderItems.id, itemId))
+    .then((rows) => rows[0]);
+
+  if (!item) {
+    return reply.code(404).send({ error: "Item not found" });
+  }
+
+  const fromFolderId = item.folderId;
+  const fromPosition = item.position;
+
+  await db.transaction(async (trx) => {
+    // Adjust positions in the original folder if moving out
+    if (fromFolderId !== toFolderId) {
+      await trx
+        .update(folderItems)
+        .set({ position: sql`${folderItems.position} - 1` })
+        .where(
+          and(
+            eq(folderItems.folderId, fromFolderId),
+            gt(folderItems.position, fromPosition)
+          )
+        );
+    } else {
+      // Reordering within the same folder
+      if (newPosition > fromPosition) {
+        await trx
+          .update(folderItems)
+          .set({ position: sql`${folderItems.position} - 1` })
+          .where(
+            and(
+              eq(folderItems.folderId, fromFolderId),
+              gt(folderItems.position, fromPosition),
+              lte(folderItems.position, newPosition)
+            )
+          );
+      } else if (newPosition < fromPosition) {
+        await trx
+          .update(folderItems)
+          .set({ position: sql`${folderItems.position} + 1` })
+          .where(
+            and(
+              eq(folderItems.folderId, fromFolderId),
+              gte(folderItems.position, newPosition),
+              lt(folderItems.position, fromPosition)
+            )
+          );
+      }
+    }
+
+    // Adjust positions in the destination folder if moved
+    if (fromFolderId !== toFolderId) {
+      await trx
+        .update(folderItems)
+        .set({ position: sql`${folderItems.position} + 1` })
+        .where(
+          and(
+            eq(folderItems.folderId, toFolderId),
+            gte(folderItems.position, newPosition)
+          )
+        );
+    }
+
+    // Move the item
+    await trx
+      .update(folderItems)
+      .set({
+        folderId: toFolderId,
+        position: newPosition,
+      })
+      .where(eq(folderItems.id, itemId));
+  });
+
+  return reply.code(200).send({ success: true });
+}
+
+async function deleteFolderHandler(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  const { folderId } = request.params as { folderId: number };
+
+  // Check if the folder exists
+  const folder = await db.query.folders.findFirst({
+    where: eq(folders.id, folderId),
+  });
+
+  if (!folder) {
+    return reply.code(404).send({ error: "Folder not found" });
+  }
+
+  // Recursive function to delete folder contents
+  async function deleteFolderRecursive(folderId: number) {
+    // Get all items in the folder
+    const items = await db
+      .select()
+      .from(folderItems)
+      .where(eq(folderItems.folderId, folderId));
+
+    for (const item of items) {
+      if (item.type === "note") {
+        // Delete the note
+        await db.delete(notes).where(eq(notes.id, item.refId));
+      } else if (item.type === "folder") {
+        // Recursively delete the subfolder
+        await deleteFolderRecursive(item.refId);
+      }
+
+      // Delete the folderItem reference itself
+      await db.delete(folderItems).where(eq(folderItems.id, item.id));
+    }
+
+    // Finally, delete the folder itself
+    await db.delete(folders).where(eq(folders.id, folderId));
+  }
+
+  await deleteFolderRecursive(folderId);
+
+  return reply.code(204).send();
+}
+
+export default folderRoutes;

--- a/routes/folder.ts
+++ b/routes/folder.ts
@@ -54,6 +54,7 @@ async function folderCreationHandler(
 
     const position = Number(count); // Add to end
 
+    // Insert the folder item
     await db.insert(folderItems).values({
       folderId,
       type: "folder",
@@ -99,6 +100,8 @@ async function folderGetHandler(request: FastifyRequest, reply: FastifyReply) {
     items.map(async (item) => {
       let data: any = null;
 
+      // Depending on the type, fetch the corresponding data
+      // Add more types as needed
       if (item.type === "note") {
         data =
           (await db.query.notes.findFirst({

--- a/routes/notes.ts
+++ b/routes/notes.ts
@@ -1,0 +1,100 @@
+import { FastifyPluginAsync, FastifyReply, FastifyRequest } from "fastify";
+import { db } from "../database/database";
+import { folderItems } from "../models/folderItems";
+import { notes } from "../models/notes";
+import { eq } from "drizzle-orm";
+
+const notesRoutes: FastifyPluginAsync = async (fastify) => {
+  fastify.post("/", notesCreationHandler);
+  fastify.get("/:noteId", noteGetHandler);
+  fastify.patch("/:noteId", noteUpdateHandler);
+  fastify.delete("/:noteId", noteDeleteHandler);
+};
+
+async function notesCreationHandler(
+  request: FastifyRequest,
+  reply: FastifyReply
+) {
+  const { title, content, createdBy, folderId } = request.body as {
+    title: string;
+    content: string;
+    createdBy: number; // This is the name of the user, not the ID
+    folderId: number; // Optional folder ID to link the note
+  };
+
+  const [note] = await db
+    .insert(notes)
+    .values({
+      title,
+      content,
+      createdBy,
+    })
+    .returning();
+
+  await db.insert(folderItems).values({
+    folderId,
+    type: "note",
+    refId: note.id,
+    position: 0,
+  });
+
+  return reply.code(201).send(note);
+}
+
+async function noteGetHandler(request: FastifyRequest, reply: FastifyReply) {
+  const { noteId } = request.params as { noteId: number };
+
+  const note = await db.query.notes.findFirst({
+    where: eq(notes.id, noteId),
+  });
+  if (!note) {
+    return reply.code(404).send({ error: "Note not found" });
+  }
+  return reply.send(note);
+}
+
+async function noteUpdateHandler(request: FastifyRequest, reply: FastifyReply) {
+  const { noteId } = request.params as { noteId: number };
+  const { title, content } = request.body as {
+    title?: string;
+    content?: string;
+  };
+
+  const updatedNote = await db
+    .update(notes)
+    .set({
+      title: title ?? undefined,
+      content: content ?? undefined,
+    })
+    .where(eq(notes.id, noteId))
+    .returning();
+
+  if (updatedNote.length === 0) {
+    return reply.code(404).send({ error: "Note not found" });
+  }
+
+  return reply.send(updatedNote[0]);
+}
+
+async function noteDeleteHandler(request: FastifyRequest, reply: FastifyReply) {
+  const { noteId } = request.params as { noteId: number };
+
+  const deletedNote = await db
+    .delete(notes)
+    .where(eq(notes.id, noteId))
+    .returning();
+
+  // Delete from folderItems as well
+  await db.delete(folderItems).where(eq(folderItems.refId, noteId));
+
+  if (deletedNote.length === 0) {
+    return reply.code(404).send({ error: "Note not found" });
+  }
+
+  // Optionally, remove from folderItems if needed
+  await db.delete(folderItems).where(eq(folderItems.refId, noteId));
+
+  return reply.code(204).send();
+}
+
+export default notesRoutes;

--- a/routes/notes.ts
+++ b/routes/notes.ts
@@ -17,16 +17,16 @@ async function notesCreationHandler(
 ) {
   const { title, content, createdBy, folderId } = request.body as {
     title: string;
-    content: string;
+    content?: string;
     createdBy: number; // This is the ID of the user creating the note
-    folderId: number; // Optional folder ID to link the note
+    folderId: number; // Folder ID to link the note
   };
 
   const [note] = await db
     .insert(notes)
     .values({
       title,
-      content,
+      content: content ?? "",
       createdBy,
     })
     .returning();

--- a/routes/notes.ts
+++ b/routes/notes.ts
@@ -18,7 +18,7 @@ async function notesCreationHandler(
   const { title, content, createdBy, folderId } = request.body as {
     title: string;
     content: string;
-    createdBy: number; // This is the name of the user, not the ID
+    createdBy: number; // This is the ID of the user creating the note
     folderId: number; // Optional folder ID to link the note
   };
 
@@ -44,13 +44,16 @@ async function notesCreationHandler(
 async function noteGetHandler(request: FastifyRequest, reply: FastifyReply) {
   const { noteId } = request.params as { noteId: number };
 
+  // Find the note by ID
   const note = await db.query.notes.findFirst({
     where: eq(notes.id, noteId),
   });
+
   if (!note) {
     return reply.code(404).send({ error: "Note not found" });
   }
-  return reply.send(note);
+
+  return reply.code(201).send(note);
 }
 
 async function noteUpdateHandler(request: FastifyRequest, reply: FastifyReply) {
@@ -60,6 +63,7 @@ async function noteUpdateHandler(request: FastifyRequest, reply: FastifyReply) {
     content?: string;
   };
 
+  //Find and update the note
   const updatedNote = await db
     .update(notes)
     .set({

--- a/routes/users.ts
+++ b/routes/users.ts
@@ -27,12 +27,16 @@ async function getUserHandler(request, reply) {
     where: (users, { eq }) => eq(users.name, name),
   });
 
+  if (!result) {
+    return reply.code(404).send({ error: "User not found" });
+  }
+
   return reply.code(200).send({ user: result });
 }
 
 //Get a User by ID
 async function getUserByIDHandler(request, reply) {
-  const { id } = request.params as { id: string };
+  const { id } = request.params as { id: number };
 
   const result = await db.query.users.findFirst({
     where: (users, { eq }) => eq(users.id, Number(id)), // convert to number if id is integer

--- a/routes/users.ts
+++ b/routes/users.ts
@@ -39,7 +39,7 @@ async function getUserByIDHandler(request, reply) {
   const { id } = request.params as { id: number };
 
   const result = await db.query.users.findFirst({
-    where: (users, { eq }) => eq(users.id, Number(id)), // convert to number if id is integer
+    where: (users, { eq }) => eq(users.id, id),
   });
 
   if (!result) {

--- a/routes/users.ts
+++ b/routes/users.ts
@@ -1,58 +1,57 @@
-import { FastifyPluginAsync } from 'fastify';
-import { db } from '../database/database';
-import { users } from '../models/users';
-
+import { FastifyPluginAsync } from "fastify";
+import { db } from "../database/database";
+import { users } from "../models/users";
 
 const userRoutes: FastifyPluginAsync = async (fastify) => {
-
-    fastify.post("/", postUserHandler);
-    fastify.get("/", getUserHandler);
-    fastify.get("/:id",getUserByIDHandler);
-
-}
+  fastify.post("/", postUserHandler);
+  fastify.get("/", getUserHandler);
+  fastify.get("/:id", getUserByIDHandler);
+};
 
 //Insert a User
-async function postUserHandler(request,reply) {
-    const { name, password } = request.body as { name: string; password:string };
-    const inserted = await db.insert(users).values({ name, password }).returning();
-  
-    return reply.code(201).send({ message: "User inserted", user: inserted[0] });
+async function postUserHandler(request, reply) {
+  const { name, password } = request.body as { name: string; password: string };
+  const inserted = await db
+    .insert(users)
+    .values({ name, password })
+    .returning();
+
+  return reply.code(201).send({ message: "User inserted", user: inserted[0] });
 }
 
 //Get a User by Name, Probably slower
 async function getUserHandler(request, reply) {
-    const { name } = request.query as { name: string };
+  const { name } = request.query as { name: string };
 
-    const result = await db.query.users.findFirst({
-        where: (users, { eq }) => eq(users.name, name),
-    });   
+  const result = await db.query.users.findFirst({
+    where: (users, { eq }) => eq(users.name, name),
+  });
 
-    return reply.code(200).send({ user: result });
+  return reply.code(200).send({ user: result });
 }
 
 //Get a User by ID
 async function getUserByIDHandler(request, reply) {
-    const { id } = request.params as { id: string };
+  const { id } = request.params as { id: string };
 
-    const result = await db.query.users.findFirst({
-        where: (users, { eq }) => eq(users.id, Number(id)), // convert to number if id is integer
-    });
+  const result = await db.query.users.findFirst({
+    where: (users, { eq }) => eq(users.id, Number(id)), // convert to number if id is integer
+  });
 
-    if (!result) {
-        return reply.code(404).send({ error: "User not found" });
-    }
+  if (!result) {
+    return reply.code(404).send({ error: "User not found" });
+  }
 
-    return reply.code(200).send({ user: result });
+  return reply.code(200).send({ user: result });
 }
 
-
 //Get UserID by Name
-async function getUserID(name:string) {
-    const result = await db.query.users.findFirst({
-        columns: {id:true},                             //Selects only the id
-        where: (users, { eq }) => eq(users.name, name),
-    })
-    return result
+async function getUserID(name: string) {
+  const result = await db.query.users.findFirst({
+    columns: { id: true }, //Selects only the id
+    where: (users, { eq }) => eq(users.name, name),
+  });
+  return result;
 }
 
 export default userRoutes;

--- a/routes/users.ts
+++ b/routes/users.ts
@@ -1,6 +1,6 @@
 import { FastifyPluginAsync } from 'fastify';
 import { db } from '../database/database';
-import { users } from '../models/user';
+import { users } from '../models/users';
 
 
 const userRoutes: FastifyPluginAsync = async (fastify) => {
@@ -25,7 +25,7 @@ async function getUserHandler(request, reply) {
 
     const result = await db.query.users.findFirst({
         where: (users, { eq }) => eq(users.name, name),
-    });
+    });   
 
     return reply.code(200).send({ user: result });
 }

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -1,5 +1,4 @@
 import "fastify";
-import { FastifyReply, FastifyRequest } from "fastify";
 
 declare module "fastify" {
   interface FastifyInstance {

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -1,8 +1,11 @@
-import 'fastify';
-import { FastifyReply, FastifyRequest } from 'fastify';
+import "fastify";
+import { FastifyReply, FastifyRequest } from "fastify";
 
-declare module 'fastify' {
+declare module "fastify" {
   interface FastifyInstance {
-    authenticate: (request: FastifyRequest, reply: FastifyReply) => Promise<void>;
+    authenticate: (
+      request: FastifyRequest,
+      reply: FastifyReply
+    ) => Promise<void>;
   }
 }


### PR DESCRIPTION
Added new models for folderItems, folders and notes.
Folders and Notes both mainly store their name, content etc.
folderItems act as a middleman in order to allow the user to rearrange their folders freely. Wanted to allow them to specifically be able to freely rearrange their folders to their own preference.

Authentication Route has a logout route now.
Campaign Route can allow the user to create campaigns, get the campaigns for a user and to let a user join a campaign.
Folder and Notes Routes have CRUD, with folder having a route to allow the shifting of items within a folder.

Dockerised backend and added github actions to auto deploy.